### PR TITLE
Create standalone cloud chat app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# obmgon-taxi
+# Chat Cloud
+
+Aplicacion web de chat creada desde cero para ejecutarse fuera de una maquina local.
+
+## Como usar
+
+Abre `index.html` en cualquier navegador moderno. El chat funciona sin servidor:
+
+- Guarda los mensajes en `localStorage`.
+- Incluye respuestas automaticas locales.
+- Permite limpiar la conversacion y usar respuestas rapidas.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,141 @@
+const STORAGE_KEY = "cloud-chat.messages";
+
+const initialMessages = [
+  {
+    author: "bot",
+    text: "Hola, soy tu chat en la nube. Escribe un mensaje para probar la conversacion.",
+    time: new Date().toISOString(),
+  },
+];
+
+const responses = [
+  "Te leo. Cuentame un poco mas.",
+  "Interesante. Que quieres hacer con esa idea?",
+  "Puedo ayudarte a ordenar los siguientes pasos.",
+  "Eso suena bien. Quieres convertirlo en una lista de tareas?",
+  "Perfecto. Sigamos construyendo desde aqui.",
+];
+
+const chatLog = document.querySelector("#chatLog");
+const chatForm = document.querySelector("#chatForm");
+const messageInput = document.querySelector("#messageInput");
+const clearButton = document.querySelector("#clearChat");
+const newChatButton = document.querySelector("#newChat");
+const template = document.querySelector("#messageTemplate");
+const quickReplies = document.querySelectorAll("[data-message]");
+
+let messages = loadMessages();
+
+renderMessages();
+messageInput.focus();
+
+chatForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  const text = messageInput.value.trim();
+  if (!text) return;
+
+  addMessage("user", text);
+  messageInput.value = "";
+
+  window.setTimeout(() => {
+    addMessage("bot", createBotReply(text));
+  }, 500);
+});
+
+clearButton.addEventListener("click", () => {
+  resetChat();
+});
+
+newChatButton.addEventListener("click", () => {
+  resetChat();
+});
+
+quickReplies.forEach((button) => {
+  button.addEventListener("click", () => {
+    messageInput.value = button.dataset.message;
+    messageInput.focus();
+  });
+});
+
+function resetChat() {
+  messages = [...initialMessages];
+  saveMessages();
+  renderMessages();
+  messageInput.focus();
+}
+
+function loadMessages() {
+  try {
+    const savedMessages = JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+    if (Array.isArray(savedMessages) && savedMessages.length > 0) {
+      return savedMessages;
+    }
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+
+  return [...initialMessages];
+}
+
+function saveMessages() {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+}
+
+function addMessage(author, text) {
+  messages.push({
+    author,
+    text,
+    time: new Date().toISOString(),
+  });
+  saveMessages();
+  renderMessages();
+}
+
+function renderMessages() {
+  chatLog.replaceChildren();
+
+  messages.forEach((message) => {
+    const item = template.content.firstElementChild.cloneNode(true);
+    item.classList.add(message.author === "user" ? "user" : "bot");
+    item.querySelector(".message-author").textContent =
+      message.author === "user" ? "Tu" : "Chat";
+    item.querySelector(".message-time").textContent = formatTime(message.time);
+    item.querySelector(".message-text").textContent = message.text;
+    chatLog.appendChild(item);
+  });
+
+  chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function formatTime(value) {
+  return new Intl.DateTimeFormat("es", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function createBotReply(text) {
+  const normalized = text.toLowerCase();
+
+  if (normalized.includes("hola") || normalized.includes("buenas")) {
+    return "Hola. Me alegra verte por aqui.";
+  }
+
+  if (normalized.includes("ayuda")) {
+    return "Claro. Dime que quieres resolver y lo dividimos en pasos simples.";
+  }
+
+  if (normalized.includes("gracias")) {
+    return "De nada. Estoy aqui para seguir ayudando.";
+  }
+
+  const index = Math.abs(hashText(text)) % responses.length;
+  return responses[index];
+}
+
+function hashText(text) {
+  return [...text].reduce((hash, char) => {
+    return (hash << 5) - hash + char.charCodeAt(0);
+  }, 0);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat Cloud</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <aside class="sidebar" aria-label="Panel del chat">
+        <div class="brand">
+          <span class="brand-mark">CC</span>
+          <div>
+            <h1>Chat Cloud</h1>
+            <p>Un chat creado desde cero en la nube.</p>
+          </div>
+        </div>
+
+        <button class="new-chat-button" id="newChat" type="button">
+          Nuevo chat
+        </button>
+
+        <section class="tip-card">
+          <h2>Privado en este navegador</h2>
+          <p>
+            Los mensajes se guardan con localStorage y no dependen de tu Mac.
+          </p>
+        </section>
+
+        <section class="quick-actions" aria-label="Respuestas rapidas">
+          <h2>Prueba rapida</h2>
+          <button class="quick-reply" type="button" data-message="Hola">
+            Hola
+          </button>
+          <button class="quick-reply" type="button" data-message="Necesito ayuda">
+            Necesito ayuda
+          </button>
+          <button class="quick-reply" type="button" data-message="Gracias">
+            Gracias
+          </button>
+        </section>
+      </aside>
+
+      <section class="chat-panel" aria-label="Aplicacion de chat">
+        <header class="chat-header">
+          <div class="conversation-meta">
+            <h2>Conversacion</h2>
+            <p>Escribe abajo y recibe una respuesta automatica local.</p>
+          </div>
+          <button class="clear-button" id="clearChat" type="button">
+            Limpiar
+          </button>
+        </header>
+
+        <section
+          class="messages"
+          id="chatLog"
+          aria-live="polite"
+          aria-label="Mensajes del chat"
+        ></section>
+
+        <form class="composer" id="chatForm">
+          <label class="sr-only" for="messageInput">Escribe un mensaje</label>
+          <textarea
+            id="messageInput"
+            name="message"
+            rows="1"
+            placeholder="Escribe aqui..."
+            autocomplete="off"
+            required
+          ></textarea>
+          <button class="send-button" type="submit">Enviar</button>
+        </form>
+      </section>
+    </main>
+
+    <template id="messageTemplate">
+      <article class="message">
+        <div class="message-bubble">
+          <strong class="message-author"></strong>
+          <p class="message-text"></p>
+        </div>
+        <time class="message-time"></time>
+      </article>
+    </template>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,345 @@
+:root {
+  color-scheme: light;
+  --bg: #eef2ff;
+  --panel: #ffffff;
+  --panel-muted: #f8fafc;
+  --text: #152033;
+  --muted: #667085;
+  --line: #d9e0ec;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --primary-soft: #dbeafe;
+  --bot: #f1f5f9;
+  --user: #2563eb;
+  --shadow: 0 24px 70px rgba(15, 23, 42, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.18), transparent 30%),
+    linear-gradient(135deg, #eef2ff 0%, #f8fafc 60%, #e0f2fe 100%);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 24px;
+  min-height: 100%;
+  padding: 24px;
+}
+
+.sidebar,
+.chat-panel {
+  background: rgba(255, 255, 255, 0.84);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(20px);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.brand {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  color: white;
+  font-weight: 800;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #2563eb, #06b6d4);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.brand p,
+.tip-card p,
+.conversation-meta p,
+.empty-state p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.new-chat-button,
+.send-button,
+.quick-reply,
+.clear-button {
+  border: 0;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.new-chat-button,
+.send-button {
+  color: white;
+  background: var(--primary);
+}
+
+.new-chat-button {
+  width: 100%;
+  padding: 14px 18px;
+  font-weight: 700;
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.24);
+}
+
+.new-chat-button:hover,
+.send-button:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.tip-card {
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: var(--panel-muted);
+}
+
+.tip-card h2,
+.quick-actions h2 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+}
+
+.quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: auto;
+}
+
+.quick-reply,
+.clear-button {
+  width: 100%;
+  padding: 12px 14px;
+  color: var(--text);
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: white;
+}
+
+.quick-reply:hover,
+.clear-button:hover {
+  background: var(--primary-soft);
+  transform: translateY(-1px);
+}
+
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 48px);
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  padding: 22px 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.conversation-meta h2 {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+}
+
+.clear-button {
+  width: auto;
+  white-space: nowrap;
+}
+
+.messages {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 360px;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.message {
+  display: grid;
+  gap: 6px;
+  max-width: min(72%, 720px);
+  animation: message-in 180ms ease-out;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.bot {
+  align-self: flex-start;
+}
+
+.message-bubble {
+  padding: 14px 16px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  border-radius: 20px;
+}
+
+.message.user .message-bubble {
+  color: white;
+  border-bottom-right-radius: 6px;
+  background: var(--user);
+}
+
+.message.bot .message-bubble {
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-bottom-left-radius: 6px;
+  background: var(--bot);
+}
+
+.message-author {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.message-time {
+  padding: 0 4px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.message.user .message-time {
+  text-align: right;
+}
+
+.composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 18px;
+  border-top: 1px solid var(--line);
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.composer textarea {
+  width: 100%;
+  min-height: 54px;
+  max-height: 160px;
+  padding: 15px 16px;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  outline: none;
+  background: white;
+  resize: vertical;
+}
+
+.composer textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.send-button {
+  padding: 0 22px;
+  font-weight: 700;
+  border-radius: 16px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+}
+
+@keyframes message-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    padding: 12px;
+  }
+
+  .sidebar {
+    gap: 16px;
+  }
+
+  .quick-actions {
+    margin-top: 0;
+  }
+
+  .chat-panel {
+    min-height: 70vh;
+  }
+
+  .chat-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .message {
+    max-width: 90%;
+  }
+
+  .composer {
+    grid-template-columns: 1fr;
+  }
+
+  .send-button {
+    min-height: 48px;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a static Chat Cloud web app with HTML, CSS, and JavaScript.
- Store messages locally with localStorage so it runs outside the user's Mac.
- Add quick replies, reset controls, and local automated responses.

## Testing
- `node --check app.js`
- Static structure check for required HTML/CSS/JS references.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c03e02b8-0ba6-4302-9dad-3b9021fa265d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c03e02b8-0ba6-4302-9dad-3b9021fa265d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

